### PR TITLE
#34: temporary disable javadoc ci rule

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,11 +27,10 @@ jobs:
         cache: 'maven'
     - name: Build and run unit tests
       run: mvn -B package --file pom.xml
-    - name: Generate Javadoc
-      run: mvn javadoc:javadoc
+    # - name: Generate Javadoc
+    #   run: mvn javadoc:javadoc
     - name: Store as artifact for downloading
       uses: actions/upload-artifact@v3
       with:
         name: target-artifact
         path: target/
-


### PR DESCRIPTION
The rule is set to be enabled at a later time when the codebase is more stable